### PR TITLE
Modify Redux DevTools extension for use in Replay Chromium

### DIFF
--- a/extension/.gitignore
+++ b/extension/.gitignore
@@ -1,2 +1,3 @@
 node_modules
-dist
+dist*/
+dev/

--- a/extension/babel.config.json
+++ b/extension/babel.config.json
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["@babel/preset-env", { "targets": "defaults" }],
+    ["@babel/preset-env", { "targets": { "chrome": "91" } }],
     "@babel/preset-react",
     "@babel/preset-typescript"
   ]

--- a/extension/src/pageScript/api/filters.ts
+++ b/extension/src/pageScript/api/filters.ts
@@ -1,4 +1,3 @@
-// import mapValues from 'lodash/mapValues';
 import type { Action } from 'redux';
 import type { LiftedState, PerformAction } from '@redux-devtools/instrument';
 import type { LocalFilter } from '@redux-devtools/utils';
@@ -15,7 +14,6 @@ export const FilterState: { [K in FilterStateValue]: FilterStateValue } = {
 };
 
 export const noFiltersApplied = (localFilter: LocalFilter | undefined) =>
-  // !predicate &&
   !localFilter &&
   (!window.devToolsOptions ||
     !window.devToolsOptions.filter ||
@@ -41,87 +39,6 @@ export function isFiltered<A extends Action<unknown>>(
   );
 }
 
-/*
-function filterActions<A extends Action<unknown>>(
-  actionsById: { [p: number]: PerformAction<A> },
-  actionSanitizer: ((action: A, id: number) => A) | undefined
-): { [p: number]: PerformAction<A> } {
-  if (!actionSanitizer) return actionsById;
-  return mapValues(actionsById, (action, id) => ({
-    ...action,
-    action: actionSanitizer(action.action, id as unknown as number),
-  }));
-}
-
-function filterStates<S>(
-  computedStates: { state: S; error?: string | undefined }[],
-  stateSanitizer: ((state: S, index: number) => S) | undefined
-) {
-  if (!stateSanitizer) return computedStates;
-  return computedStates.map((state, idx) => ({
-    ...state,
-    state: stateSanitizer(state.state, idx),
-  }));
-}
-
-export function filterState<S, A extends Action<unknown>>(
-  state: LiftedState<S, A, unknown>,
-  localFilter: LocalFilter | undefined,
-  stateSanitizer: ((state: S, index: number) => S) | undefined,
-  actionSanitizer: ((action: A, id: number) => A) | undefined,
-  predicate: ((state: S, action: A) => boolean) | undefined
-): LiftedState<S, A, unknown> {
-  if (predicate || !noFiltersApplied(localFilter)) {
-    const filteredStagedActionIds: number[] = [];
-    const filteredComputedStates: { state: S; error?: string | undefined }[] =
-      [];
-    const sanitizedActionsById: { [p: number]: PerformAction<A> } | undefined =
-      actionSanitizer && {};
-    const { actionsById } = state;
-    const { computedStates } = state;
-
-    state.stagedActionIds.forEach((id, idx) => {
-      const liftedAction = actionsById[id];
-      if (!liftedAction) return;
-      const currAction = liftedAction.action;
-      const liftedState = computedStates[idx];
-      const currState = liftedState.state;
-      if (idx) {
-        if (predicate && !predicate(currState, currAction)) return;
-        if (isFiltered(currAction, localFilter)) return;
-      }
-
-      filteredStagedActionIds.push(id);
-      filteredComputedStates.push(
-        stateSanitizer
-          ? { ...liftedState, state: stateSanitizer(currState, idx) }
-          : liftedState
-      );
-      if (actionSanitizer) {
-        sanitizedActionsById![id] = {
-          ...liftedAction,
-          action: actionSanitizer(currAction, id),
-        };
-      }
-    });
-
-    return {
-      ...state,
-      actionsById: sanitizedActionsById || actionsById,
-      stagedActionIds: filteredStagedActionIds,
-      computedStates: filteredComputedStates,
-    };
-  }
-
-  if (!stateSanitizer && !actionSanitizer) return state;
-  return {
-    ...state,
-    actionsById: filterActions(state.actionsById, actionSanitizer),
-    computedStates: filterStates(state.computedStates, stateSanitizer),
-  };
-}
-*/
-
 export interface PartialLiftedState<S, A extends Action<unknown>> {
   readonly actionsById: { [actionId: number]: PerformAction<A> };
   readonly computedStates: { state: S; error?: string }[];
@@ -130,69 +47,3 @@ export interface PartialLiftedState<S, A extends Action<unknown>> {
   readonly nextActionId: number;
   readonly committedState?: S;
 }
-/*
-export function startingFrom<S, A extends Action<unknown>>(
-  sendingActionId: number,
-  state: LiftedState<S, A, unknown>,
-  localFilter: LocalFilter | undefined,
-  stateSanitizer: (<S>(state: S, index: number) => S) | undefined,
-  actionSanitizer:
-    | (<A extends Action<unknown>>(action: A, id: number) => A)
-    | undefined,
-  predicate:
-    | (<S, A extends Action<unknown>>(state: S, action: A) => boolean)
-    | undefined
-): LiftedState<S, A, unknown> | PartialLiftedState<S, A> | undefined {
-  const stagedActionIds = state.stagedActionIds;
-  if (sendingActionId <= stagedActionIds[1]) return state;
-  const index = stagedActionIds.indexOf(sendingActionId);
-  if (index === -1) return state;
-
-  const shouldFilter = predicate || !noFiltersApplied(localFilter);
-  const filteredStagedActionIds = shouldFilter ? [0] : stagedActionIds;
-  const actionsById = state.actionsById;
-  const computedStates = state.computedStates;
-  const newActionsById: { [key: number]: PerformAction<A> } = {};
-  const newComputedStates = [];
-  let key;
-  let currAction;
-  let currState;
-
-  for (let i = shouldFilter ? 1 : index; i < stagedActionIds.length; i++) {
-    key = stagedActionIds[i];
-    currAction = actionsById[key];
-    currState = computedStates[i];
-
-    if (shouldFilter) {
-      if (
-        (predicate && !predicate(currState.state, currAction.action)) ||
-        isFiltered(currAction.action, localFilter)
-      ) {
-        continue;
-      }
-      filteredStagedActionIds.push(key);
-      if (i < index) continue;
-    }
-
-    newActionsById[key] = !actionSanitizer
-      ? currAction
-      : { ...currAction, action: actionSanitizer(currAction.action, key) };
-    newComputedStates.push(
-      !stateSanitizer
-        ? currState
-        : { ...currState, state: stateSanitizer(currState.state, i) }
-    );
-  }
-
-  if (newComputedStates.length === 0) return undefined;
-
-  return {
-    actionsById: newActionsById,
-    computedStates: newComputedStates,
-    stagedActionIds: filteredStagedActionIds,
-    currentStateIndex: state.currentStateIndex,
-    nextActionId: state.nextActionId,
-  };
-}
-
-*/

--- a/extension/src/pageScript/api/filters.ts
+++ b/extension/src/pageScript/api/filters.ts
@@ -1,7 +1,7 @@
-import mapValues from 'lodash/mapValues';
-import { Action } from 'redux';
-import { LiftedState, PerformAction } from '@redux-devtools/instrument';
-import { LocalFilter } from '@redux-devtools/utils';
+// import mapValues from 'lodash/mapValues';
+import type { Action } from 'redux';
+import type { LiftedState, PerformAction } from '@redux-devtools/instrument';
+import type { LocalFilter } from '@redux-devtools/utils';
 
 export type FilterStateValue =
   | 'DO_NOT_FILTER'
@@ -41,6 +41,7 @@ export function isFiltered<A extends Action<unknown>>(
   );
 }
 
+/*
 function filterActions<A extends Action<unknown>>(
   actionsById: { [p: number]: PerformAction<A> },
   actionSanitizer: ((action: A, id: number) => A) | undefined
@@ -119,6 +120,7 @@ export function filterState<S, A extends Action<unknown>>(
     computedStates: filterStates(state.computedStates, stateSanitizer),
   };
 }
+*/
 
 export interface PartialLiftedState<S, A extends Action<unknown>> {
   readonly actionsById: { [actionId: number]: PerformAction<A> };
@@ -128,7 +130,7 @@ export interface PartialLiftedState<S, A extends Action<unknown>> {
   readonly nextActionId: number;
   readonly committedState?: S;
 }
-
+/*
 export function startingFrom<S, A extends Action<unknown>>(
   sendingActionId: number,
   state: LiftedState<S, A, unknown>,
@@ -192,3 +194,5 @@ export function startingFrom<S, A extends Action<unknown>>(
     nextActionId: state.nextActionId,
   };
 }
+
+*/

--- a/extension/src/pageScript/api/index.ts
+++ b/extension/src/pageScript/api/index.ts
@@ -1,14 +1,7 @@
 import type { Options } from 'jsan';
-// import throttle from 'lodash/throttle';
 import type { AnyAction } from 'redux';
-// import { immutableSerialize } from '@redux-devtools/serialize';
-import type {
-  // getActionsArray,
-  // getLocalFilter,
-  LocalFilter,
-} from '@redux-devtools/utils';
+import type { LocalFilter } from '@redux-devtools/utils';
 import { isFiltered, PartialLiftedState } from './filters';
-// import importState from './importState';
 import generateId from './generateInstanceId';
 import type { Config } from '../index';
 import type { Action } from 'redux';
@@ -43,86 +36,11 @@ export function getLocalFilter(config: Config): LocalFilter | undefined {
   return undefined;
 }
 
-/*
-function windowReplacer(key: string, value: unknown) {
-  if (value && (value as Window).window === value) {
-    return '[WINDOW]';
-  }
-  return value;
-}
-
-function tryCatchStringify(obj: unknown) {
-  try {
-    return JSON.stringify(obj);
-  } catch (err) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.log('Failed to stringify', err);
-    }
-    return jsan.stringify(obj, windowReplacer, undefined, {
-      circular: '[CIRCULAR]',
-      date: true,
-    });
-  }
-}
-
-let stringifyWarned: boolean;
-function stringify(obj: unknown, serialize?: Serialize | undefined) {
-  const str =
-    typeof serialize === 'undefined'
-      ? tryCatchStringify(obj)
-      : jsan.stringify(obj, serialize.replacer, undefined, serialize.options);
-
-  if (!stringifyWarned && str && str.length > 16 * 1024 * 1024) {
-    console.warn(
-      'Application state or actions payloads are too large making Redux DevTools serialization slow and consuming a lot of memory. See https://github.com/reduxjs/redux-devtools-extension/blob/master/docs/Troubleshooting.md#excessive-use-of-memory-and-cpu on how to configure it.'
-    );
-    stringifyWarned = true;
-  }
-
-  return str;
-}
-*/
-
 export interface Serialize {
   readonly replacer?: (key: string, value: unknown) => unknown;
   readonly reviver?: (key: string, value: unknown) => unknown;
   readonly options?: Options | boolean;
 }
-
-/*
-export function getSerializeParameter(config: Config) {
-  const serialize = config.serialize;
-  if (serialize) {
-    if (serialize === true) return { options: true };
-    if (serialize.immutable) {
-      const immutableSerializer = immutableSerialize(
-        serialize.immutable,
-        serialize.refs,
-        serialize.replacer,
-        serialize.reviver
-      );
-      return {
-        replacer: immutableSerializer.replacer,
-        reviver: immutableSerializer.reviver,
-        options:
-          typeof serialize.options === 'object'
-            ? { ...immutableSerializer.options, ...serialize.options }
-            : immutableSerializer.options,
-      };
-    }
-    if (!serialize.replacer && !serialize.reviver) {
-      return { options: serialize.options };
-    }
-    return {
-      replacer: serialize.replacer,
-      reviver: serialize.reviver,
-      options: serialize.options || true,
-    };
-  }
-
-  return undefined;
-}
-*/
 
 interface InitInstancePageScriptToContentScriptMessage {
   readonly type: 'INIT_INSTANCE';
@@ -234,73 +152,6 @@ export type PageScriptToContentScriptMessage<S, A extends Action<unknown>> =
   | PageScriptToContentScriptMessageWithoutDisconnect<S, A>
   | DisconnectMessage;
 
-function post<S, A extends Action<unknown>>(
-  message: PageScriptToContentScriptMessage<S, A>
-) {
-  window.postMessage(message, '*');
-}
-
-function getStackTrace(
-  config: Config,
-  toExcludeFromTrace: Function | undefined
-) {
-  if (!config.trace) return undefined;
-  if (typeof config.trace === 'function') return config.trace();
-
-  let stack;
-  let extraFrames = 0;
-  let prevStackTraceLimit;
-  const traceLimit = config.traceLimit;
-  const error = Error();
-  if (Error.captureStackTrace) {
-    if (Error.stackTraceLimit < traceLimit!) {
-      prevStackTraceLimit = Error.stackTraceLimit;
-      Error.stackTraceLimit = traceLimit!;
-    }
-    Error.captureStackTrace(error, toExcludeFromTrace);
-  } else {
-    extraFrames = 3;
-  }
-  stack = error.stack;
-  if (prevStackTraceLimit) Error.stackTraceLimit = prevStackTraceLimit;
-  if (
-    extraFrames ||
-    typeof Error.stackTraceLimit !== 'number' ||
-    Error.stackTraceLimit > traceLimit!
-  ) {
-    const frames = stack!.split('\n');
-    if (frames.length > traceLimit!) {
-      stack = frames
-        .slice(0, traceLimit! + extraFrames + (frames[0] === 'Error' ? 1 : 0))
-        .join('\n');
-    }
-  }
-  return stack;
-}
-
-function amendActionType<A extends Action<unknown>>(
-  action:
-    | A
-    | StructuralPerformAction<A>
-    | StructuralPerformAction<A>[]
-    | string,
-  config: Config,
-  toExcludeFromTrace: Function | undefined
-): StructuralPerformAction<A> {
-  let timestamp = Date.now();
-  let stack = getStackTrace(config, toExcludeFromTrace);
-  if (typeof action === 'string') {
-    return { action: { type: action } as A, timestamp, stack };
-  }
-  if (!(action as A).type)
-    return { action: { type: 'update' } as A, timestamp, stack };
-  if ((action as StructuralPerformAction<A>).action)
-    return (
-      stack ? { stack, ...action } : action
-    ) as StructuralPerformAction<A>;
-  return { action, timestamp, stack } as StructuralPerformAction<A>;
-}
-
 interface LiftedMessage {
   readonly type: 'LIFTED';
   readonly liftedState: { readonly isPaused: boolean | undefined };
@@ -400,59 +251,10 @@ type ToContentScriptMessage<S, A extends Action<unknown>> =
   | GetReportMessage
   | StopMessage;
 
-/*
-export function toContentScript<S, A extends Action<unknown>>(
-  message: ToContentScriptMessage<S, A>,
-  serializeState?: Serialize | undefined,
-  serializeAction?: Serialize | undefined
-) {
-  if (message.type === 'ACTION') {
-    post({
-      ...message,
-      action: stringify(message.action, serializeAction),
-      payload: stringify(message.payload, serializeState),
-    });
-  } else if (message.type === 'STATE') {
-    const { actionsById, computedStates, committedState, ...rest } =
-      message.payload;
-    post({
-      ...message,
-      payload: rest,
-      actionsById: stringify(actionsById, serializeAction),
-      computedStates: stringify(computedStates, serializeState),
-      committedState: typeof committedState !== 'undefined',
-    });
-  } else if (message.type === 'PARTIAL_STATE') {
-    const { actionsById, computedStates, committedState, ...rest } =
-      message.payload;
-    post({
-      ...message,
-      payload: rest,
-      actionsById: stringify(actionsById, serializeAction),
-      computedStates: stringify(computedStates, serializeState),
-      committedState: typeof committedState !== 'undefined',
-    });
-  } else if (message.type === 'EXPORT') {
-    post({
-      ...message,
-      payload: stringify(message.payload, serializeAction),
-      committedState:
-        typeof message.committedState !== 'undefined'
-          ? stringify(message.committedState, serializeState)
-          : (message.committedState as undefined),
-    });
-  } else {
-    post(message);
-  }
-}
-*/
-
 export type ExtractedExtensionConfig = Pick<
   Config,
   'stateSanitizer' | 'actionSanitizer' | 'predicate'
 > & {
-  // serializeState: Serializer;
-  // serializeAction: Serializer;
   instanceId: number;
   isFiltered: typeof isFiltered;
   localFilter: LocalFilter | undefined;
@@ -479,7 +281,7 @@ export function saveReplayAnnotation(
   window.__RECORD_REPLAY_ANNOTATION_HOOK__(
     'redux-devtools-setup',
     JSON.stringify({
-      type: 'init',
+      type: 'action',
       actionType: action.type,
       connectionType,
       instanceId,
@@ -493,108 +295,6 @@ export function saveReplayAnnotation(
     config,
   };
 }
-
-/*
-export function sendMessage<S, A extends Action<unknown>>(
-  action: StructuralPerformAction<A> | StructuralPerformAction<A>[],
-  state: LiftedState<S, A, unknown>,
-  config: Config,
-  instanceId?: number,
-  name?: string
-) {
-  let amendedAction = action;
-  if (typeof config !== 'object') {
-    // Legacy: sending actions not from connected part
-    config = {}; // eslint-disable-line no-param-reassign
-    if (action) amendedAction = amendActionType(action, config, sendMessage);
-  }
-  if (action) {
-    toContentScript(
-      {
-        type: 'ACTION',
-        action: amendedAction,
-        payload: state,
-        maxAge: config.maxAge!,
-        source,
-        name: config.name || name,
-        instanceId: config.instanceId || instanceId || 1,
-      },
-      config.serialize as Serialize | undefined,
-      config.serialize as Serialize | undefined
-    );
-  } else {
-    toContentScript<S, A>(
-      {
-        type: 'STATE',
-        action: amendedAction,
-        payload: state,
-        maxAge: config.maxAge,
-        source,
-        name: config.name || name,
-        instanceId: config.instanceId || instanceId || 1,
-      },
-      config.serialize as Serialize | undefined,
-      config.serialize as Serialize | undefined
-    );
-  }
-}
-*/
-
-/*
-function handleMessages(event: MessageEvent<ContentScriptToPageScriptMessage>) {
-  if (process.env.BABEL_ENV !== 'test' && (!event || event.source !== window)) {
-    return;
-  }
-  const message = event.data;
-  if (!message || message.source !== '@devtools-extension') return;
-  Object.keys(listeners).forEach((id) => {
-    if (message.id && id !== message.id) return;
-    const listenersForId = listeners[id];
-    if (typeof listenersForId === 'function') listenersForId(message);
-    else {
-      listenersForId.forEach((fn) => {
-        fn(message);
-      });
-    }
-  });
-}
-
-
-export function setListener(
-  onMessage: (message: ContentScriptToPageScriptMessage) => void,
-  instanceId: number
-) {
-  listeners[instanceId] = onMessage;
-  window.addEventListener('message', handleMessages, false);
-}
-*/
-
-/*
-const liftListener =
-  <S, A extends Action<unknown>>(
-    listener: (message: ListenerMessage<S, A>) => void,
-    config: Config
-  ) =>
-  (message: ContentScriptToPageScriptMessage) => {
-    if (message.type === 'IMPORT') {
-      listener({
-        type: 'DISPATCH',
-        payload: {
-          type: 'IMPORT_STATE',
-          ...importState<S, A>(message.state, config)!,
-        },
-      });
-    } else {
-      listener(message);
-    }
-  };
-
-
-export function disconnect() {
-  window.removeEventListener('message', handleMessages);
-  post({ type: 'DISCONNECT', source });
-}
-*/
 
 export interface ConnectResponse {
   init: <S, A extends Action<unknown>>(
@@ -622,21 +322,11 @@ export function connect(preConfig: Config): ConnectResponse {
         ? document.title
         : `Instance ${instanceId}`;
   }
-  // if (config.serialize) config.serialize = getSerializeParameter(config);
-  // const actionCreators = config.actionCreators || {};
-  // const latency = config.latency;
   const localFilter = getLocalFilter(config);
-  const autoPause = config.autoPause;
-  let isPaused = autoPause;
-  // let delayedActions: StructuralPerformAction<Action<unknown>>[] = [];
-  // let delayedStates: LiftedState<unknown, Action<unknown>, unknown>[] = [];
-
   let { stateSanitizer, actionSanitizer, predicate } = config;
 
   const extractedExtensionConfig: ExtractedExtensionConfig = {
     instanceId: instanceId,
-    // serializeState,
-    // serializeAction,
     stateSanitizer,
     actionSanitizer,
     predicate,
@@ -644,54 +334,17 @@ export function connect(preConfig: Config): ConnectResponse {
     isFiltered,
   };
 
-  /*
-  const rootListener = (action: ContentScriptToPageScriptMessage) => {
-    if (autoPause) {
-      if (action.type === 'START') isPaused = false;
-      else if (action.type === 'STOP') isPaused = true;
-    }
-    if (action.type === 'DISPATCH') {
-      const payload = action.payload;
-      if (payload.type === 'PAUSE_RECORDING') {
-        isPaused = payload.status;
-        toContentScript({
-          type: 'LIFTED',
-          liftedState: { isPaused },
-          instanceId: id,
-          source,
-        });
-      }
-    }
-  };
-
-  listeners[id] = [rootListener];
-  */
-
   const subscribe = <S, A extends Action<unknown>>(
     listener: (message: ListenerMessage<S, A>) => void
   ) => {
     if (!listener) return undefined;
-    // const liftedListener = liftListener(listener, config);
-    // const listenersForId = listeners[id] as ((
-    //   message: ContentScriptToPageScriptMessage
-    // ) => void)[];
-    // listenersForId.push(liftedListener);
 
-    return function unsubscribe() {
-      // const index = listenersForId.indexOf(liftedListener);
-      // listenersForId.splice(index, 1);
-    };
+    return function unsubscribe() {};
   };
 
   const unsubscribe = () => {
     delete listeners[instanceId];
   };
-
-  // const sendDelayed = throttle(() => {
-  //   sendMessage(delayedActions, delayedStates as any, config);
-  //   delayedActions = [];
-  //   delayedStates = [];
-  // }, latency);
 
   const send = <S, A extends Action<unknown>>(
     action: A,
@@ -706,16 +359,6 @@ export function connect(preConfig: Config): ConnectResponse {
     if (typeof action === 'string') {
       amendedAction = { type: action };
     }
-    // if (config.getActionType) {
-    //   amendedAction = config.getActionType(action);
-    //   if (typeof amendedAction !== 'object') {
-    //     amendedAction = {
-    //       action: { type: amendedAction },
-    //       timestamp: Date.now(),
-    //     } as unknown as A;
-    //   }
-    // }
-    // amendedAction = amendActionType(amendedAction, config, send);
 
     saveReplayAnnotation(
       amendedAction,
@@ -725,46 +368,6 @@ export function connect(preConfig: Config): ConnectResponse {
       config
     );
     return;
-
-    /*
-    if (
-      isPaused ||
-      isFiltered(action, localFilter) ||
-      (predicate && !predicate(state, action))
-    ) {
-      return;
-    }
-
-    let amendedAction: A | StructuralPerformAction<A> = action;
-    const amendedState = config.stateSanitizer
-      ? config.stateSanitizer(state)
-      : state;
-    if (action) {
-      if (config.getActionType) {
-        amendedAction = config.getActionType(action);
-        if (typeof amendedAction !== 'object') {
-          amendedAction = {
-            action: { type: amendedAction },
-            timestamp: Date.now(),
-          } as unknown as A;
-        }
-      } else if (config.actionSanitizer) {
-        amendedAction = config.actionSanitizer(action);
-      }
-      amendedAction = amendActionType(amendedAction, config, send);
-      if (latency) {
-        delayedActions.push(amendedAction);
-        delayedStates.push(amendedState);
-        sendDelayed();
-        return;
-      }
-    }
-    sendMessage(
-      amendedAction as StructuralPerformAction<A>,
-      amendedState,
-      config
-    );
-    */
   };
 
   const init = <S, A extends Action<unknown>>(
@@ -775,42 +378,9 @@ export function connect(preConfig: Config): ConnectResponse {
       'redux-devtools-setup',
       JSON.stringify({ type: 'init', connectionType: 'generic', instanceId })
     );
-
-    /*
-    const message: InitMessage<S, A> = {
-      type: 'INIT',
-      payload: stringify(state, config.serialize as Serialize | undefined),
-      instanceId: instanceId,
-      source,
-    };
-    if (liftedData && Array.isArray(liftedData)) {
-      // Legacy
-      message.action = stringify(liftedData);
-      message.name = config.name;
-    } else {
-      if (liftedData) {
-        message.liftedState = liftedData;
-        if (liftedData.isPaused) isPaused = true;
-      }
-      message.libConfig = {
-        actionCreators: JSON.stringify(getActionsArray(actionCreators)),
-        name: config.name || document.title,
-        features: config.features,
-        serialize: !!config.serialize,
-        type: config.type,
-      };
-    }
-    post(message);
-    */
   };
 
-  const error = (payload: string) => {
-    post({ type: 'ERROR', payload, instanceId: instanceId, source });
-  };
-
-  // window.addEventListener('message', handleMessages, false);
-
-  // post({ type: 'INIT_INSTANCE', instanceId: instanceId, source });
+  const error = (payload: string) => {};
 
   return {
     init,
@@ -819,12 +389,4 @@ export function connect(preConfig: Config): ConnectResponse {
     send,
     error,
   };
-}
-
-export function isInIframe() {
-  try {
-    return window.self !== window.top;
-  } catch (e) {
-    return true;
-  }
 }

--- a/extension/src/pageScript/api/index.ts
+++ b/extension/src/pageScript/api/index.ts
@@ -1,17 +1,15 @@
 import type { Options } from 'jsan';
 import type { AnyAction } from 'redux';
 import type { LocalFilter } from '@redux-devtools/utils';
-import { isFiltered, PartialLiftedState } from './filters';
+import { isFiltered } from './filters';
 import generateId from './generateInstanceId';
 import type { Config } from '../index';
 import type { Action } from 'redux';
-import type { LiftedState, PerformAction } from '@redux-devtools/instrument';
-import type { LibConfig } from '@redux-devtools/app';
+import type { LiftedState } from '@redux-devtools/instrument';
 import type {
   ContentScriptToPageScriptMessage,
   ListenerMessage,
 } from '../../contentScript';
-import type { Position } from './openWindow';
 
 const listeners: {
   [instanceId: string]:
@@ -42,173 +40,30 @@ export interface Serialize {
   readonly options?: Options | boolean;
 }
 
-interface InitInstancePageScriptToContentScriptMessage {
-  readonly type: 'INIT_INSTANCE';
-  readonly instanceId: number;
-  readonly source: typeof source;
-}
-
-interface DisconnectMessage {
-  readonly type: 'DISCONNECT';
-  readonly source: typeof source;
-}
-
-interface InitMessage<S, A extends Action<unknown>> {
-  readonly type: 'INIT';
-  readonly payload: string;
-  readonly instanceId: number;
-  readonly source: typeof source;
-  action?: string;
-  name?: string | undefined;
-  liftedState?: LiftedState<S, A, unknown>;
-  libConfig?: LibConfig;
-}
-
-interface SerializedPartialLiftedState {
-  readonly stagedActionIds: readonly number[];
-  readonly currentStateIndex: number;
-  readonly nextActionId: number;
-}
-
-interface SerializedPartialStateMessage {
-  readonly type: 'PARTIAL_STATE';
-  readonly payload: SerializedPartialLiftedState;
-  readonly source: typeof source;
-  readonly instanceId: number;
-  readonly maxAge: number;
-  readonly actionsById: string;
-  readonly computedStates: string;
-  readonly committedState: boolean;
-}
-
-interface SerializedExportMessage {
-  readonly type: 'EXPORT';
-  readonly payload: string;
-  readonly committedState: string | undefined;
-  readonly source: typeof source;
-  readonly instanceId: number;
-}
-
-interface SerializedActionMessage {
-  readonly type: 'ACTION';
-  readonly payload: string;
-  readonly source: typeof source;
-  readonly instanceId: number;
-  readonly action: string;
-  readonly maxAge: number;
-  readonly nextActionId?: number;
-}
-
-interface SerializedStateMessage<S, A extends Action<unknown>> {
-  readonly type: 'STATE';
-  readonly payload: Omit<
-    LiftedState<S, A, unknown>,
-    'actionsById' | 'computedStates' | 'committedState'
-  >;
-  readonly source: typeof source;
-  readonly instanceId: number;
-  readonly libConfig?: LibConfig;
-  readonly actionsById: string;
-  readonly computedStates: string;
-  readonly committedState: boolean;
-}
-
-interface OpenMessage {
-  readonly source: typeof source;
-  readonly type: 'OPEN';
-  readonly position: Position;
-}
-
 export type PageScriptToContentScriptMessageForwardedToMonitors<
   S,
   A extends Action<unknown>
-> =
-  | InitMessage<S, A>
-  | LiftedMessage
-  | SerializedPartialStateMessage
-  | SerializedExportMessage
-  | SerializedActionMessage
-  | SerializedStateMessage<S, A>;
+> = any;
 
 export type PageScriptToContentScriptMessageWithoutDisconnectOrInitInstance<
   S,
   A extends Action<unknown>
-> =
-  | PageScriptToContentScriptMessageForwardedToMonitors<S, A>
-  | ErrorMessage
-  | GetReportMessage
-  | StopMessage
-  | OpenMessage;
+> = any;
 
 export type PageScriptToContentScriptMessageWithoutDisconnect<
   S,
   A extends Action<unknown>
-> =
-  | PageScriptToContentScriptMessageWithoutDisconnectOrInitInstance<S, A>
-  | InitInstancePageScriptToContentScriptMessage
-  | InitInstanceMessage;
+> = any;
 
-export type PageScriptToContentScriptMessage<S, A extends Action<unknown>> =
-  | PageScriptToContentScriptMessageWithoutDisconnect<S, A>
-  | DisconnectMessage;
-
-interface LiftedMessage {
-  readonly type: 'LIFTED';
-  readonly liftedState: { readonly isPaused: boolean | undefined };
-  readonly instanceId: number;
-  readonly source: typeof source;
-}
-
-interface PartialStateMessage<S, A extends Action<unknown>> {
-  readonly type: 'PARTIAL_STATE';
-  readonly payload: PartialLiftedState<S, A>;
-  readonly source: typeof source;
-  readonly instanceId: number;
-  readonly maxAge: number;
-}
-
-interface ExportMessage<S, A extends Action<unknown>> {
-  readonly type: 'EXPORT';
-  readonly payload: readonly A[];
-  readonly committedState: S;
-  readonly source: typeof source;
-  readonly instanceId: number;
-}
+export type PageScriptToContentScriptMessage<
+  S,
+  A extends Action<unknown>
+> = any;
 
 export interface StructuralPerformAction<A extends Action<unknown>> {
   readonly action: A;
   readonly timestamp?: number;
   readonly stack?: string;
-}
-
-type SingleUserAction<A extends Action<unknown>> =
-  | PerformAction<A>
-  | StructuralPerformAction<A>
-  | A;
-type UserAction<A extends Action<unknown>> =
-  | SingleUserAction<A>
-  | readonly SingleUserAction<A>[];
-
-interface ActionMessage<S, A extends Action<unknown>> {
-  readonly type: 'ACTION';
-  readonly payload: S;
-  readonly source: typeof source;
-  readonly instanceId: number;
-  readonly action: UserAction<A>;
-  readonly maxAge: number;
-  readonly nextActionId?: number;
-  readonly name?: string;
-}
-
-interface StateMessage<S, A extends Action<unknown>> {
-  readonly type: 'STATE';
-  readonly payload: LiftedState<S, A, unknown>;
-  readonly source: typeof source;
-  readonly instanceId: number;
-  readonly libConfig?: LibConfig;
-  readonly action?: UserAction<A>;
-  readonly maxAge?: number;
-  readonly name?: string;
 }
 
 export interface ErrorMessage {
@@ -218,38 +73,6 @@ export interface ErrorMessage {
   readonly instanceId: number;
   readonly message?: string | undefined;
 }
-
-interface InitInstanceMessage {
-  readonly type: 'INIT_INSTANCE';
-  readonly payload: undefined;
-  readonly source: typeof source;
-  readonly instanceId: number;
-}
-
-interface GetReportMessage {
-  readonly type: 'GET_REPORT';
-  readonly payload: string;
-  readonly source: typeof source;
-  readonly instanceId: number;
-}
-
-interface StopMessage {
-  readonly type: 'STOP';
-  readonly payload: undefined;
-  readonly source: typeof source;
-  readonly instanceId: number;
-}
-
-type ToContentScriptMessage<S, A extends Action<unknown>> =
-  | LiftedMessage
-  | PartialStateMessage<S, A>
-  | ExportMessage<S, A>
-  | ActionMessage<S, A>
-  | StateMessage<S, A>
-  | ErrorMessage
-  | InitInstanceMessage
-  | GetReportMessage
-  | StopMessage;
 
 export type ExtractedExtensionConfig = Pick<
   Config,
@@ -312,7 +135,32 @@ export interface ConnectResponse {
   error: (payload: string) => void;
 }
 
-export function connect(preConfig: Config): ConnectResponse {
+export function sendMessage<S, A extends Action<unknown>>(
+  action: string | A,
+  state: LiftedState<S, A, unknown>,
+  preConfig: Config = {},
+  instanceId?: number,
+  name?: string
+) {
+  if (!action || !(action as A).type) {
+    action = { type: 'update' } as A;
+  } else if (typeof action === 'string') {
+    action = { type: action } as A;
+  }
+
+  const [config, extractedExtensionConfig] = extractExtensionConfig(preConfig);
+  instanceId = instanceId ?? extractedExtensionConfig.instanceId;
+
+  saveReplayAnnotation(
+    action,
+    state,
+    'generic',
+    extractedExtensionConfig,
+    config
+  );
+}
+
+export function extractExtensionConfig(preConfig: Config) {
   const config = preConfig || {};
   const instanceId = generateId(config.instanceId);
   if (!config.instanceId) config.instanceId = instanceId;
@@ -333,6 +181,13 @@ export function connect(preConfig: Config): ConnectResponse {
     localFilter,
     isFiltered,
   };
+
+  return [config, extractedExtensionConfig] as const;
+}
+
+export function connect(preConfig: Config): ConnectResponse {
+  const [config, extractedExtensionConfig] = extractExtensionConfig(preConfig);
+  const { instanceId } = extractedExtensionConfig;
 
   const subscribe = <S, A extends Action<unknown>>(
     listener: (message: ListenerMessage<S, A>) => void

--- a/extension/src/pageScript/index.ts
+++ b/extension/src/pageScript/index.ts
@@ -1,50 +1,19 @@
-import type { ActionCreatorObject } from '@redux-devtools/utils';
 import type { AnyAction, Store } from 'redux';
-// import throttle from 'lodash/throttle';
 import type {
   Action,
   ActionCreator,
-  Dispatch,
   PreloadedState,
   Reducer,
   StoreEnhancer,
   StoreEnhancerStoreCreator,
 } from 'redux';
 import type Immutable from 'immutable';
-import type {
-  EnhancedStore,
-  LiftedAction,
-  LiftedState,
-  PerformAction,
-} from '@redux-devtools/instrument';
-import type {
-  CustomAction,
-  DispatchAction,
-  LibConfig,
-  Features,
-} from '@redux-devtools/app';
-// import configureStore, { getUrlParam } from './enhancerStore';
+import type { LiftedAction, LiftedState } from '@redux-devtools/instrument';
+import type { Features } from '@redux-devtools/app';
 import type { Options } from '../options/syncOptions';
 import { isFiltered } from './api/filters';
-// import Monitor from './Monitor';
-// import {
-//   noFiltersApplied,
-//   isFiltered,
-//   filterState,
-//   startingFrom,
-// } from './api/filters';
-import notifyErrors from './api/notifyErrors';
-//import importState from './api/importState';
-// import openWindow, { Position } from './api/openWindow';
 import generateId from './api/generateInstanceId';
 import {
-  // toContentScript,
-  // sendMessage,
-  // setListener,
-  // connect,
-  //  disconnect,
-  // isInIframe,
-  // getSerializeParameter,
   getLocalFilter,
   saveReplayAnnotation,
   Serialize,
@@ -54,25 +23,9 @@ import {
 } from './api';
 import type { ContentScriptToPageScriptMessage } from '../contentScript';
 
-// type EnhancedStoreWithInitialDispatch<
-//   S,
-//   A extends Action<unknown>,
-//   MonitorState
-// > = EnhancedStore<S, A, MonitorState> & { initialDispatch: Dispatch<A> };
-
-const source = '@devtools-page';
 let stores: {
   [K in string | number]: Store;
 } = {};
-let reportId: string | null | undefined;
-
-function deprecateParam(oldParam: string, newParam: string) {
-  /* eslint-disable no-console */
-  console.warn(
-    `${oldParam} parameter is deprecated, use ${newParam} instead: https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md`
-  );
-  /* eslint-enable no-console */
-}
 
 export interface SerializeWithImmutable extends Serialize {
   readonly immutable?: typeof Immutable;
@@ -156,40 +109,19 @@ declare global {
   }
 }
 
-// type Serializer = ReturnType<typeof getSerializeParameter>;
-
-const toReg = (str: string) =>
-  str !== '' ? str.split('\n').filter(Boolean).join('|') : null;
-
-export const isAllowed = (localOptions: Options) =>
-  !localOptions ||
-  localOptions.inject ||
-  !localOptions.urls ||
-  location.href.match(toReg(localOptions.urls)!);
-
 function __REDUX_DEVTOOLS_EXTENSION__<S, A extends Action<unknown>>(
   config?: Config
 ): StoreEnhancer {
-  /* eslint-disable no-param-reassign */
   if (typeof config !== 'object') config = {};
-  /* eslint-enable no-param-reassign */
   if (!window.devToolsOptions) window.devToolsOptions = {} as any;
 
   let store: Store<any, AnyAction>;
-  let errorOccurred = false;
-  let maxAge: number | undefined;
-  let actionCreators: readonly ActionCreatorObject[];
-  let sendingActionId = 1;
   const instanceId = generateId(config.instanceId);
   const localFilter = getLocalFilter(config);
-  // const serializeState = getSerializeParameter(config);
-  // const serializeAction = getSerializeParameter(config);
   let { stateSanitizer, actionSanitizer, predicate, latency = 500 } = config;
 
   const extractedExtensionConfig: ExtractedExtensionConfig = {
     instanceId,
-    // serializeState,
-    // serializeAction,
     stateSanitizer,
     actionSanitizer,
     predicate,
@@ -197,293 +129,12 @@ function __REDUX_DEVTOOLS_EXTENSION__<S, A extends Action<unknown>>(
     isFiltered,
   };
 
-  // Deprecate actionsWhitelist and actionsBlacklist
-  // if (config.actionsWhitelist) {
-  //   deprecateParam('actionsWhiteList', 'actionsAllowlist');
-  // }
-  // if (config.actionsBlacklist) {
-  //   deprecateParam('actionsBlacklist', 'actionsDenylist');
-  // }
-
-  /*
-  const relayState = throttle(
-    (
-      liftedState?: LiftedState<S, A, unknown> | undefined,
-      libConfig?: LibConfig
-    ) => {
-      relayAction.cancel();
-      const state = liftedState || store.getState();
-      sendingActionId = state.nextActionId;
-      toContentScript(
-        {
-          type: 'STATE',
-          payload: filterState(
-            state,
-            localFilter,
-            stateSanitizer,
-            actionSanitizer,
-            predicate
-          ),
-          source,
-          instanceId,
-          libConfig,
-        },
-        serializeState,
-        serializeAction
-      );
-    },
-    latency
-  );
-  */
-
-  // const monitor = new Monitor(relayState);
-
-  /*
-  const relayAction = throttle(() => {
-    const liftedState = store.getState();
-    const nextActionId = liftedState.nextActionId;
-    const currentActionId = nextActionId - 1;
-    const liftedAction = liftedState.actionsById[currentActionId];
-
-    // Send a single action
-    if (sendingActionId === currentActionId) {
-      sendingActionId = nextActionId;
-      const action = liftedAction.action;
-      const computedStates = liftedState.computedStates;
-      if (
-        isFiltered(action, localFilter) ||
-        (predicate &&
-          !predicate(computedStates[computedStates.length - 1].state, action))
-      ) {
-        return;
-      }
-      const state =
-        liftedState.computedStates[liftedState.computedStates.length - 1].state;
-      toContentScript(
-        {
-          type: 'ACTION',
-          payload: !stateSanitizer
-            ? state
-            : stateSanitizer(state, nextActionId - 1),
-          source,
-          instanceId,
-          action: !actionSanitizer
-            ? liftedState.actionsById[nextActionId - 1]
-            : actionSanitizer(
-                liftedState.actionsById[nextActionId - 1].action,
-                nextActionId - 1
-              ),
-          maxAge: getMaxAge(),
-          nextActionId,
-        },
-        serializeState,
-        serializeAction
-      );
-      return;
-    }
-    
-
-    // Send multiple actions
-    const payload = startingFrom(
-      sendingActionId,
-      liftedState,
-      localFilter,
-      stateSanitizer,
-      actionSanitizer,
-      predicate
-    );
-    sendingActionId = nextActionId;
-    if (typeof payload === 'undefined') return;
-    if ('skippedActionIds' in payload) {
-      toContentScript(
-        {
-          type: 'STATE',
-          payload: filterState(
-            payload,
-            localFilter,
-            stateSanitizer,
-            actionSanitizer,
-            predicate
-          ),
-          source,
-          instanceId,
-        },
-        serializeState,
-        serializeAction
-      );
-      return;
-    }
-    toContentScript(
-      {
-        type: 'PARTIAL_STATE',
-        payload,
-        source,
-        instanceId,
-        maxAge: getMaxAge(),
-      },
-      serializeState,
-      serializeAction
-    );
-  }, latency);
-  */
-
-  /*
-  function onMessage(message: ContentScriptToPageScriptMessage) {
-    switch (message.type) {
-      case 'DISPATCH':
-        dispatchMonitorAction(message.payload);
-        return;
-      case 'ACTION':
-        dispatchRemotely(message.payload);
-        return;
-      case 'IMPORT':
-        importPayloadFrom(message.state);
-        return;
-      case 'EXPORT':
-        exportState();
-        return;
-      case 'UPDATE':
-        relayState();
-        return;
-      case 'START':
-        monitor.start(true);
-        if (!actionCreators && config!.actionCreators) {
-          actionCreators = getActionsArray(config!.actionCreators);
-        }
-        relayState(undefined, {
-          name: config!.name || document.title,
-          actionCreators: JSON.stringify(actionCreators),
-          features: config!.features,
-          serialize: !!config!.serialize,
-          type: 'redux',
-        });
-
-        if (reportId) {
-          toContentScript(
-            {
-              type: 'GET_REPORT',
-              payload: reportId,
-              source,
-              instanceId,
-            },
-            serializeState,
-            serializeAction
-          );
-          reportId = null;
-        }
-        return;
-      case 'STOP':
-        monitor.stop();
-        relayAction.cancel();
-        relayState.cancel();
-        if (!message.failed) {
-          toContentScript(
-            {
-              type: 'STOP',
-              payload: undefined,
-              source,
-              instanceId,
-            },
-            serializeState,
-            serializeAction
-          );
-        }
-    }
-  }
-  */
-
-  /*
-  const filteredActionIds: number[] = []; // simple circular buffer of non-excluded actions with fixed maxAge-1 length
-  const getMaxAge = (
-    liftedAction?: LiftedAction<S, A, unknown>,
-    liftedState?: LiftedState<S, A, unknown> | undefined
-  ) => {
-    let m = (config && config.maxAge) || window.devToolsOptions.maxAge || 50;
-    if (
-      !liftedAction ||
-      noFiltersApplied(localFilter) ||
-      !(liftedAction as PerformAction<A>).action
-    ) {
-      return m;
-    }
-    if (!maxAge || maxAge < m) maxAge = m; // it can be modified in process on options page
-    if (isFiltered((liftedAction as PerformAction<A>).action, localFilter)) {
-      // TODO: check also predicate && !predicate(state, action) with current state
-      maxAge++;
-    } else {
-      filteredActionIds.push(liftedState!.nextActionId);
-      if (filteredActionIds.length >= m) {
-        const stagedActionIds = liftedState!.stagedActionIds;
-        let i = 1;
-        while (
-          maxAge > m &&
-          filteredActionIds.indexOf(stagedActionIds[i]) === -1
-        ) {
-          maxAge--;
-          i++;
-        }
-        filteredActionIds.shift();
-      }
-    }
-    return maxAge;
-  };
-  */
-
   function init() {
     window.__RECORD_REPLAY_ANNOTATION_HOOK__(
       'redux-devtools-setup',
       JSON.stringify({ type: 'init', connectionType: 'redux', instanceId })
     );
-    /*
-    setListener(onMessage, instanceId);
-    notifyErrors(() => {
-      errorOccurred = true;
-      const state = store.liftedStore.getState();
-      if (state.computedStates[state.currentStateIndex].error) {
-        relayState(state);
-      }
-      return true;
-    });
-
-    toContentScript(
-      {
-        type: 'INIT_INSTANCE',
-        payload: undefined,
-        source,
-        instanceId,
-      },
-      serializeState,
-      serializeAction
-    );
-    store.subscribe(handleChange);
-
-    if (typeof reportId === 'undefined') {
-      reportId = getUrlParam('remotedev_report');
-      if (reportId) openWindow();
-    }
-    */
   }
-
-  /*
-  function handleChange() {
-    if (!monitor.active) return;
-    if (!errorOccurred && !monitor.isMonitorAction()) {
-      relayAction();
-      return;
-    }
-    if (monitor.isPaused() || monitor.isLocked() || monitor.isTimeTraveling()) {
-      return;
-    }
-    const liftedState = store.getState();
-    if (
-      errorOccurred &&
-      !liftedState.computedStates[liftedState.currentStateIndex].error
-    ) {
-      errorOccurred = false;
-    }
-    relayState(liftedState);
-  }
-  */
 
   const enhance =
     (): StoreEnhancer =>
@@ -495,9 +146,6 @@ function __REDUX_DEVTOOLS_EXTENSION__<S, A extends Action<unknown>>(
         initialState_?: PreloadedState<S2>
       ) => {
         const originalStore = next(reducer_, initialState_);
-        if (!isAllowed(window.devToolsOptions)) {
-          return originalStore;
-        }
 
         const newStore: Store<S2, A2> = {
           ...originalStore,
@@ -517,19 +165,7 @@ function __REDUX_DEVTOOLS_EXTENSION__<S, A extends Action<unknown>>(
         // @ts-ignore
         store = stores[instanceId] = newStore;
 
-        // store = stores[instanceId] = configureStore(
-        //   next as StoreEnhancerStoreCreator,
-        //   monitor.reducer,
-        //   {
-        //     ...config,
-        //     maxAge: getMaxAge as any,
-        //   }
-        // )(reducer_, initialState_) as any;
-
         init();
-        // if (isInIframe()) setTimeout(init, 3000);
-        // else init();
-
         return store;
       };
     };
@@ -543,6 +179,7 @@ declare global {
   }
 }
 
+// TODO reimplement `send()` and `connect()`
 // noinspection JSAnnotator
 window.__REDUX_DEVTOOLS_EXTENSION__ = __REDUX_DEVTOOLS_EXTENSION__ as any;
 window.__REDUX_DEVTOOLS_EXTENSION__.open = () => {};
@@ -551,26 +188,6 @@ window.__REDUX_DEVTOOLS_EXTENSION__.send = () => {}; // sendMessage;
 window.__REDUX_DEVTOOLS_EXTENSION__.listen = () => {};
 window.__REDUX_DEVTOOLS_EXTENSION__.connect = (config: Config) => null as any; // connect;
 window.__REDUX_DEVTOOLS_EXTENSION__.disconnect = () => {}; // disconnect;
-
-/*
-const preEnhancer =
-  (instanceId: number): StoreEnhancer =>
-  (next) =>
-  (reducer, preloadedState) => {
-    const store = next(reducer, preloadedState);
-
-    if (stores[instanceId]) {
-      (stores[instanceId].initialDispatch as any) = store.dispatch;
-    }
-
-    return {
-      ...store,
-      dispatch: (...args: any[]) =>
-        !window.__REDUX_DEVTOOLS_EXTENSION_LOCKED__ &&
-        (store.dispatch as any)(...args),
-    } as any;
-  };
-*/
 
 export type InferComposedStoreExt<StoreEnhancers> = StoreEnhancers extends [
   infer HeadStoreEnhancer,

--- a/extension/webpack.config.js
+++ b/extension/webpack.config.js
@@ -8,29 +8,7 @@ module.exports = function (env) {
     mode: env.production ? 'production' : 'development',
     devtool: env.production ? undefined : 'eval-source-map',
     entry: {
-      background: [
-        path.resolve(__dirname, 'src/chromeApiMock'),
-        path.resolve(__dirname, 'src/background/index'),
-      ],
-      options: [
-        path.resolve(__dirname, 'src/chromeApiMock'),
-        path.resolve(__dirname, 'src/options/index'),
-      ],
-      window: [path.resolve(__dirname, 'src/window/index')],
-      remote: [path.resolve(__dirname, 'src/remote/index')],
-      devpanel: [
-        path.resolve(__dirname, 'src/chromeApiMock'),
-        path.resolve(__dirname, 'src/devpanel/index'),
-      ],
-      devtools: path.resolve(__dirname, 'src/devtools/index'),
-      content: [
-        path.resolve(__dirname, 'src/chromeApiMock'),
-        path.resolve(__dirname, 'src/contentScript/index'),
-      ],
       page: path.join(__dirname, 'src/pageScript'),
-      ...(env.production
-        ? {}
-        : { pagewrap: path.resolve(__dirname, 'src/pageScriptWrap') }),
     },
     output: {
       filename: '[name].bundle.js',

--- a/extension/webpack.config.js
+++ b/extension/webpack.config.js
@@ -35,6 +35,9 @@ module.exports = function (env) {
     output: {
       filename: '[name].bundle.js',
     },
+    optimization: {
+      minimize: false,
+    },
     plugins: [
       new webpack.DefinePlugin({
         'process.env.BABEL_ENV': JSON.stringify(process.env.NODE_ENV),


### PR DESCRIPTION
This PR:

- Rewrites the internals of the Redux DevTools extension to cut out 90% of the actual logic, and instead pass the current `(state, action)` into a specific function where we can save a Replay annotation with those variables in scope, as well as an object containing the user's DevTools configuration settings.  

This enables the backend Redux DevTools Routine to collect the execution points and check which actions should be filtered out, and allows the UI to show `action` and `state` using our object inspector.